### PR TITLE
Implement automatic usage of AWS creds for keyword bucket, bump UI to hide authentication when adding dataset in LINC

### DIFF
--- a/app/models/dataset/credential/CredentialService.scala
+++ b/app/models/dataset/credential/CredentialService.scala
@@ -35,7 +35,8 @@ class CredentialService @Inject()(credentialDAO: CredentialDAO,
                                     organizationId.toString))
       case DataVaultService.schemeS3 =>
         val s3PrivateBucketConfigKeyword = conf.WebKnossos.S3PrivateBucketConfig.keyword
-        if (uri.toString.contains(s3PrivateBucketConfigKeyword)) {
+        val isPrivateBucketEnabled = conf.WebKnossos.S3PrivateBucketConfig.enabled
+        if (uri.toString.contains(s3PrivateBucketConfigKeyword) && isPrivateBucketEnabled) {
           val s3AccessIdKey = sys.env("AWS_ACCESS_KEY_ID")
           val s3SecretAccessKey = sys.env("AWS_ACCESS_KEY")
           Some(S3AccessKeyCredential(uri.toString, s3AccessIdKey, s3SecretAccessKey, userId.toString, organizationId.toString))

--- a/app/models/dataset/credential/CredentialService.scala
+++ b/app/models/dataset/credential/CredentialService.scala
@@ -16,8 +16,7 @@ import java.net.URI
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 
-class CredentialService @Inject()(credentialDAO: CredentialDAO,
-                                  conf: WkConf) {
+class CredentialService @Inject()(credentialDAO: CredentialDAO, conf: WkConf) {
 
   def createCredentialOpt(uri: URI,
                           credentialIdentifier: Option[String],
@@ -39,7 +38,12 @@ class CredentialService @Inject()(credentialDAO: CredentialDAO,
         if (uri.toString.contains(s3PrivateBucketConfigKeyword) && isPrivateBucketEnabled) {
           val s3AccessIdKey = sys.env("AWS_ACCESS_KEY_ID")
           val s3SecretAccessKey = sys.env("AWS_ACCESS_KEY")
-          Some(S3AccessKeyCredential(uri.toString, s3AccessIdKey, s3SecretAccessKey, userId.toString, organizationId.toString))
+          Some(
+            S3AccessKeyCredential(uri.toString,
+                                  s3AccessIdKey,
+                                  s3SecretAccessKey,
+                                  userId.toString,
+                                  organizationId.toString))
         } else {
           (credentialIdentifier, credentialSecret) match {
             case (Some(keyId), Some(secretKey)) =>
@@ -55,7 +59,6 @@ class CredentialService @Inject()(credentialDAO: CredentialDAO,
       case _ =>
         None
     }
-
 
   def insertOne(credential: DataVaultCredential)(implicit ec: ExecutionContext): Fox[ObjectId] = {
     val _id = ObjectId.generate

--- a/app/models/dataset/credential/CredentialService.scala
+++ b/app/models/dataset/credential/CredentialService.scala
@@ -37,8 +37,8 @@ class CredentialService @Inject()(credentialDAO: CredentialDAO,
         val s3PrivateBucketConfigKeyword = conf.WebKnossos.S3PrivateBucketConfig.keyword
         val isPrivateBucketEnabled = conf.WebKnossos.S3PrivateBucketConfig.enabled
         if (uri.toString.contains(s3PrivateBucketConfigKeyword) && isPrivateBucketEnabled) {
-          val s3AccessIdKey = sys.env.get("AWS_ACCESS_KEY_ID")
-          val s3SecretAccessKey = sys.env.get("AWS_ACCESS_KEY")
+          val s3AccessIdKey = sys.env("AWS_ACCESS_KEY_ID")
+          val s3SecretAccessKey = sys.env("AWS_ACCESS_KEY")
           Some(S3AccessKeyCredential(uri.toString, s3AccessIdKey, s3SecretAccessKey, userId.toString, organizationId.toString))
         } else {
           (credentialIdentifier, credentialSecret) match {

--- a/app/models/dataset/credential/CredentialService.scala
+++ b/app/models/dataset/credential/CredentialService.scala
@@ -37,8 +37,8 @@ class CredentialService @Inject()(credentialDAO: CredentialDAO,
         val s3PrivateBucketConfigKeyword = conf.WebKnossos.S3PrivateBucketConfig.keyword
         val isPrivateBucketEnabled = conf.WebKnossos.S3PrivateBucketConfig.enabled
         if (uri.toString.contains(s3PrivateBucketConfigKeyword) && isPrivateBucketEnabled) {
-          val s3AccessIdKey = sys.env("AWS_ACCESS_KEY_ID")
-          val s3SecretAccessKey = sys.env("AWS_ACCESS_KEY")
+          val s3AccessIdKey = sys.env.get("AWS_ACCESS_KEY_ID")
+          val s3SecretAccessKey = sys.env.get("AWS_ACCESS_KEY")
           Some(S3AccessKeyCredential(uri.toString, s3AccessIdKey, s3SecretAccessKey, userId.toString, organizationId.toString))
         } else {
           (credentialIdentifier, credentialSecret) match {

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -99,6 +99,7 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader with L
 
     object S3PrivateBucketConfig {
       val keyword: String = get[String]("webKnossos.s3PrivateBucketConfig.keyword")
+      val enabled: Boolean = get[Boolean]("webKnossos.s3PrivateBucketConfig.enabled")
     }
 
     val operatorData: String = get[String]("webKnossos.operatorData")

--- a/app/utils/WkConf.scala
+++ b/app/utils/WkConf.scala
@@ -97,6 +97,10 @@ class WkConf @Inject()(configuration: Configuration) extends ConfigReader with L
       val content: String = get[String]("webKnossos.securityTxt.content")
     }
 
+    object S3PrivateBucketConfig {
+      val keyword: String = get[String]("webKnossos.s3PrivateBucketConfig.keyword")
+    }
+
     val operatorData: String = get[String]("webKnossos.operatorData")
     val children = List(User, Tasks, Cache, SampleOrganization, FetchUsedStorage, TermsOfService)
   }

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -28,7 +28,7 @@ Option[String], openGraphImage: Option[String] )
     } else {
     <meta name="robot" content="noindex" />
     }
-    <link rel="shortcut icon" type="image/png" href="/assets/images/favicon.png" />
+    <link rel="shortcut icon" type="image/png" href="/assets/images/favicon.ico" />
     <link
       rel="stylesheet"
       type="text/css"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -129,6 +129,9 @@ Expires: 2024-07-03T10:00:00.000Z
 Preferred-Languages: en,de
     """
   }
+  s3PrivateBucketConfig {
+    keyword = "lincbrain"
+  }
 }
 
 singleSignOn {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -130,7 +130,7 @@ Preferred-Languages: en,de
     """
   }
   s3PrivateBucketConfig {
-    keyword = "lincbrain"
+    keyword = "linc-brain-mit-prod"
     enabled = true
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -131,6 +131,7 @@ Preferred-Languages: en,de
   }
   s3PrivateBucketConfig {
     keyword = "lincbrain"
+    enabled = true
   }
 }
 

--- a/frontend/javascripts/admin/dataset/dataset_add_remote_view.tsx
+++ b/frontend/javascripts/admin/dataset/dataset_add_remote_view.tsx
@@ -523,18 +523,18 @@ function AddRemoteLayer({
       >
         <Input />
       </FormItem>
-      <FormItem label="Authentication">
-        <RadioGroup
-          defaultValue="hide"
-          value={showCredentialsFields ? "show" : "hide"}
-          onChange={(e) => setShowCredentialsFields(e.target.value === "show")}
-        >
-          <Radio value="hide">{selectedProtocol === "https" ? "None" : "Anonymous"}</Radio>
-          <Radio value="show">
-            {selectedProtocol === "https" ? "Basic authentication" : "With credentials"}
-          </Radio>
-        </RadioGroup>
-      </FormItem>
+      {/*<FormItem label="Authentication">*/}
+      {/*  <RadioGroup*/}
+      {/*    defaultValue="hide"*/}
+      {/*    value={showCredentialsFields ? "show" : "hide"}*/}
+      {/*    onChange={(e) => setShowCredentialsFields(e.target.value === "show")}*/}
+      {/*  >*/}
+      {/*    <Radio value="hide">{selectedProtocol === "https" ? "None" : "Anonymous"}</Radio>*/}
+      {/*    <Radio value="show">*/}
+      {/*      {selectedProtocol === "https" ? "Basic authentication" : "With credentials"}*/}
+      {/*    </Radio>*/}
+      {/*  </RadioGroup>*/}
+      {/*</FormItem>*/}
       {showCredentialsFields ? (
         selectedProtocol === "gs" ? (
           <GoogleAuthFormItem fileList={fileList} handleChange={handleChange} />


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] ...

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
