### PR TITLE
Resolve annotation download issue with application.conf.uri fix

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,5 +1,5 @@
 http {
-  uri = "http://localhost:9000"
+  uri = "http://webknossos-staging.lincbrain.org:9000"
   port = 9000
 }
 


### PR DESCRIPTION
### URL of deployed dev instance (used for testing):
- https://___.webknossos.xyz

### Steps to test:
- abc

### TODOs:
- [ ] ...

### Issues:
- fixes #

------
(Please delete unneeded items, merge only when none are left open)
- [ ] Updated [changelog](../blob/master/CHANGELOG.unreleased.md#unreleased)
- [ ] Updated [migration guide](../blob/master/MIGRATIONS.unreleased.md#unreleased) if applicable
- [ ] Updated [documentation](../blob/master/docs) if applicable
- [ ] Adapted [wk-libs python client](https://github.com/scalableminds/webknossos-libs/tree/master/webknossos/webknossos/client) if relevant API parts change
- [ ] Removed dev-only changes like prints and application.conf edits
- [ ] Considered [common edge cases](../blob/master/.github/common_edge_cases.md)
- [ ] Needs datastore update after deployment
